### PR TITLE
Implement resolve topic feature

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -213,6 +213,10 @@ TopicObjectSlim:
           type: number
         postercount:
           type: number
+        # Instructed to make this addition by ChatGPT, code by copilot autocomplete
+        # Add resolve field to topic schema
+        resolve:
+          type: number
         scheduled:
           type: number
         deleted:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -112,6 +112,10 @@ paths:
     $ref: 'write/topics/tid.yaml'
   /topics/{tid}/state:
     $ref: 'write/topics/tid/state.yaml'
+  # Instructed to add by ChatGPT, code copied from lines above
+  # Defines path to an API endpoint for resolving a topic
+  /topics/{tid}/resolve:
+    $ref: 'write/topics/tid/resolve.yaml'
   /topics/{tid}/lock:
     $ref: 'write/topics/tid/lock.yaml'
   /topics/{tid}/pin:

--- a/public/openapi/write/topics/tid/resolve.yaml
+++ b/public/openapi/write/topics/tid/resolve.yaml
@@ -1,0 +1,28 @@
+# File instructed to write by ChatGPT, code copied from pin.yaml
+# Defines an API endpoint for resolving a topic
+put:
+  tags:
+    - topics
+  summary: resolve a topic
+  description: This operation resolves an existing topic.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully resolved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -62,7 +62,9 @@ define('forum/topic', [
         addDropupHandler();
         addRepliesHandler();
         addPostsPreviewHandler();
-
+        // instructed to add by ChatGPT, written by ChatGPT
+        // call handling function to handle click of resolve button
+        handleResolveButton();
         handleBookmark(tid);
 
         $(window).on('scroll', utils.debounce(updateTopicTitle, 250));
@@ -71,6 +73,34 @@ define('forum/topic', [
 
         hooks.fire('action:topic.loaded', ajaxify.data);
     };
+
+    /**
+     * Instructed to write by ChatGPT, written by ChatGPT
+     * Attaches a click event listener to a resolve button and updates the topic's resolution status.
+     * @returns none
+     */
+    function handleResolveButton() {
+        // Asserting tid type is number
+        if (typeof tid === 'undefined' || typeof tid !== 'number') {
+            console.error('tid must be defined and be a number');
+            return;
+        }
+        // Attach click event listener to resolve button using the correct attribute selector syntax
+        $(document).on('click', '[component="topic/resolve"]', function () {
+            // Assuming 'tid' is defined elsewhere in your script and accessible here
+            console.log('clicked resolve button');
+            api.put('/topics/' + tid + '/resolve', { resolve: 1 })
+                .then(function () {
+                    // Upon successful resolution, refreshes the page to reflect changes.
+                    location.reload();
+                })
+                .catch(function (error) {
+                    // If the PUT request fails, displays an error message to the user.
+                    // It uses a custom alert system to show the error message or a default message if none is provided.
+                    alerts.error(error.message || 'Failed to update topic resolution status.');
+                });
+        });
+    }
 
     function handleTopicSearch() {
         require(['mousetrap'], (mousetrap) => {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -22,6 +22,9 @@ define('forum/topic/events', [
         'event:topic_deleted': threadTools.setDeleteState,
         'event:topic_restored': threadTools.setDeleteState,
         'event:topic_purged': onTopicPurged,
+        // Instructed to add by ChatGPT, code written by ChatGPT
+        // create event for topic resolved
+        'event:topic_resolved': onTopicResolved,
 
         'event:topic_locked': threadTools.setLockedState,
         'event:topic_unlocked': threadTools.setLockedState,
@@ -92,6 +95,12 @@ define('forum/topic/events', [
         ) {
             ajaxify.go('category/' + ajaxify.data.category.slug, null, true);
         }
+    }
+
+    // Instructed to add by ChatGPT, code written by ChatGPT
+    // Event handler for when a topic is resolved
+    function onTopicResolved(data) {
+        console.log('Topic resolved', data);
     }
 
     function onTopicMoved(data) {

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -65,6 +65,14 @@ topicsAPI.create = async function (caller, data) {
     return result.topicData;
 };
 
+// Instructed to add by ChatGPT to fulfill testing purposes, code written by ChatGPT
+// Set up API to resolve topic
+topicsAPI.resolve = async function (caller, data) {
+    await doTopicAction('resolve', 'event:topic_resolved', caller, {
+        tids: data.tids,
+    });
+};
+
 topicsAPI.reply = async function (caller, data) {
     if (!data || !data.tid || (meta.config.minimumPostLength !== 0 && !data.content)) {
         throw new Error('[[error:invalid-data]]');

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -40,6 +40,30 @@ Topics.reply = async (req, res) => {
         await db.deleteObjectField('locks', id);
     }
 };
+/**
+ * Code instructed and written by ChatGPT
+ * Resolves topic with tid and uid from parameters
+ * @param {Object} req - The request object from Express.js, containing the parameters and user information.
+ * @param {Object} res - The response object from Express.js, used to send back the formatted API response.
+ */
+Topics.resolve = async (req, res) => {
+    // Asserting that req.params and req.uid are of expected types.
+    if (typeof req !== 'object' || typeof res !== 'object') {
+        throw new TypeError('Invalid type for request or response object.');
+    }
+    if (typeof req.params !== 'object' || !req.params.tid || typeof req.params.tid !== 'string') {
+        throw new TypeError('Request parameters are not as expected. "tid" should be a string and not empty.');
+    }
+    if (typeof req.uid !== 'string' && typeof req.uid !== 'number') {
+        throw new TypeError('User ID (uid) must be a string or number.');
+    }
+    // Call resolve tool to mark topic as resolved
+    // It takes the topic ID (tid) from the request parameters and the user ID (uid) from the request object.
+    await topics.tools.resolve(req.params.tid, req.uid);
+    // Send a success response to the client.
+    // It formats the response as per the API's standard, with a 200 OK status code.
+    helpers.formatApiResponse(200, res);
+};
 
 async function lockPosting(req, error) {
     const id = req.uid > 0 ? req.uid : req.sessionID;

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -48,7 +48,9 @@ privsTopics.get = async function (tid, uid) {
         'posts:view_deleted': privData['posts:view_deleted'] || isAdministrator,
         read: privData.read || isAdministrator,
         purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,
-
+        // instructed to add by ChatGPT
+        // add privilege for resolve topics, only topic owner, admin, or mod
+        can_resolve: isOwner || isAdminOrMod,
         view_thread_tools: editable || deletable,
         editable: editable,
         deletable: deletable,

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -26,7 +26,9 @@ module.exports = function () {
 
     setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
     setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
-
+    // Instructed to write by ChatGPT, code copied from line 46
+    // Add route for resolve topic
+    setupApiRoute(router, 'put', '/:tid/resolve', [...middlewares], controllers.write.topics.resolve);
     setupApiRoute(router, 'put', '/:tid/follow', [...middlewares, middleware.assert.topic], controllers.write.topics.follow);
     setupApiRoute(router, 'delete', '/:tid/follow', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow);
     setupApiRoute(router, 'put', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.ignore);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -38,6 +38,8 @@ module.exports = function (Topics) {
             postcount: 0,
             viewcount: 0,
             isAnonymous: isAnonymous, // store anonymous status
+            // Add resolve field to topic's data, defaults to 0 for unresolved (1 for resolved), type: number
+            resolve: 0,
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {
@@ -226,7 +228,13 @@ module.exports = function (Topics) {
             topicInfo,
         ] = await Promise.all([
             posts.getUserInfoForPosts([postData.uid], uid),
-            Topics.getTopicFields(tid, ['tid', 'uid', 'title', 'slug', 'cid', 'postcount', 'mainPid', 'scheduled']),
+            /**
+             * Code instructed to add and written by ChatGPT
+             * Retrieves specified fields for a given topic.
+             * Add resolve field to topic's field getter
+             * resolve type: number
+             */
+            Topics.getTopicFields(tid, ['tid', 'uid', 'title', 'slug', 'cid', 'postcount', 'mainPid', 'scheduled', 'resolve']),
             Topics.addParentPosts([postData]),
             Topics.syncBacklinks(postData),
             posts.parsePost(postData),

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -7,12 +7,16 @@ const categories = require('../categories');
 const utils = require('../utils');
 const translator = require('../translator');
 const plugins = require('../plugins');
-
+/**
+ * Instructed to add 'resolve' field to intFields constant by ChatGPT
+ * intFields: array of strings representing topic field names, topic fields have integer value
+ * intFields used to parse integer fields from topic object
+ */
 const intFields = [
     'tid', 'cid', 'uid', 'mainPid', 'postcount',
     'viewcount', 'postercount', 'deleted', 'locked', 'pinned',
     'pinExpiry', 'timestamp', 'upvotes', 'downvotes', 'lastposttime',
-    'deleterUid',
+    'deleterUid', 'resolve',
 ];
 
 module.exports = function (Topics) {

--- a/test/topics.js
+++ b/test/topics.js
@@ -714,7 +714,7 @@ describe('Topic\'s', () => {
                 // Check that the error message matches the expected no-privileges error
                 assert.strictEqual(error.message, '[[error:no-privileges]]');
             }
-        });        
+        });
 
         it('should pin topic', async () => {
             await apiTopics.pin({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });

--- a/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
@@ -17,4 +17,24 @@
     <!-- IMPORT partials/thread_tools.tpl -->
     </div>
     <!-- IMPORT partials/topic/reply-button.tpl -->
+    <!-- Code written by ChatGPT -->
+    <!-- Add Resolve button only available to users with correct privileges to resolve the topic -->
+    <!-- IF privileges.can_resolve -->
+        <button 
+        component="topic/resolve" 
+        class="btn btn-sm btn-default" 
+        type="button" 
+        {{{if resolve}}}disabled{{{end}}}>
+        <!-- Button content changes based on resolution state -->
+        {{{if resolve}}}
+            <!-- Displayed if the topic is already resolved -->
+            <i class="fa fa-fw fa-check"></i>
+            <span class="visible-sm-inline visible-md-inline visible-lg-inline">Already Resolved</span>
+        {{{else}}}
+            <!-- Displayed if the topic is not resolved yet -->
+            <i class="fa"></i>
+            <span class="visible-sm-inline visible-md-inline visible-lg-inline">Mark as Resolved</span>
+        {{{end}}}
+    </button> 
+    <!-- ENDIF privileges.can_resolve -->
 </div>

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -16,6 +16,13 @@
                         {{{each icons}}}{@value}{{{end}}}
                     </span>
                     <span component="topic/title">{title}</span>
+                    <!-- Code written by ChatGPT -->
+                    <!-- Add resolve status -->
+                    <!-- IF resolve -->
+                        <small style="text-align: right; color: green;">Resolved</small>
+                    <!-- ELSE -->
+                        <small style="text-align: right; color: red;">Unresolved</small>
+                    <!-- ENDIF resolve -->
                 </span>
             </h1>
 


### PR DESCRIPTION
Implements User story 4 #51 
Resolves #45, #46, #47, #48, #49, #50
**Summary**
- Added resolve button component and resolution status display on topic frontend
- Added resolve field to Topic object
- Edited user privileges so only topic owners, administrators, and moderators can resolve a topic
- Added API endpoint for resolve topic
- Set up backend event handling of resolve button clicks (event listeners)
- Added controllers function to actually update the resolve field given appropriate permissions

**Motivation**
I personally benefited a lot from the Piazza resolve functionality: 
- As a student, I can indicate to instructors that I need more help
- As a TA, I can quickly see which students still need more help
I believe adding this feature to NodeBB would make it more applicable as a Q&A forum for the classroom, since instructors and students alike will benefit from this feature with a more efficient process of asking questions and giving and receiving answers.

**Changes made**
Did not edit or remove any existing functionalities
Added new resolve functionality

**Testing done**
Visual testing
- created new topic, check that I can mark the new topic as resolved and resolve status is updated on topic page
- created new topic, register for a new account, check that new account can not see the resolve button to resolve the topic, however new account can see resolve status
- log in as administrator, check that welcome to NodeBB can be resolved and resolve status is updated on topic page
Automated testing
- check that a topic can be resolved with its owner's uid 
- check that a topic cannot be resolved with other uids

**Checklist**

- [ ] Unit tests for changes
- [ ] Updated User Guide
- [ ] PR created with documentation

**Next steps**
- A good next implementation would be to add a filter in the General Discussion for resolved / unresolved topics


