### PR TITLE
Set up JSHint and added relevant config files. Closes #63

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,25 @@
+// Generated with help of GPT4 with query "jshint config for NodeBB"
+// If we want to make our own rules we will modify this here
+{
+    "node": true,
+    "browser": true,
+    "esversion": 9,
+    "globals": {
+      "define": true,
+      "require": true,
+      "module": true,
+      "Promise": true
+    },
+    "curly": true,
+    "undef": true,
+    "unused": true,
+    "eqeqeq": true,
+    "varstmt": false,
+    "strict": "global",
+    "laxbreak": true,
+    "laxcomma": true,
+    "expr": true,
+    "onevar": false,
+    "quotmark": "single"
+  }
+  


### PR DESCRIPTION
<img width="616" alt="Screenshot 2024-03-15 at 1 08 50 PM" src="https://github.com/CMU-313/spring24-nodebb-apple/assets/39356275/609fbad8-918e-4225-ad69-b689013e2daf">
<img width="616" alt="Screenshot 2024-03-15 at 1 11 27 PM" src="https://github.com/CMU-313/spring24-nodebb-apple/assets/39356275/116a2536-89ca-4403-a0d6-2af9a0458747">

I included two screenshots to show the functionality of JSHint working. The one screenshot shows a working version (no output meaning that JSHint ran without picking up any issues and didn't note any warnings), and the other screenshot shows a version with a modified config file to change the quote style from "single" to "double" (which results in many warnings since we are purposely violating our own custom rules)

